### PR TITLE
カレンダーのビューを作成

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -59,6 +59,8 @@ gem "jquery-rails"
 
 gem "kaminari"
 
+gem "simple_calendar"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -304,6 +304,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    simple_calendar (3.0.4)
+      rails (>= 6.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -370,6 +372,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sassc-rails
+  simple_calendar
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css");
 @import "simple_calendar";
 @import "custom";
+@import "calendar";

--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "bootstrap";
 @import url("https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css");
+@import "simple_calendar";
 @import "custom";

--- a/rails/app/assets/stylesheets/calendar.scss
+++ b/rails/app/assets/stylesheets/calendar.scss
@@ -1,0 +1,12 @@
+.simple-calendar {
+  .today {
+    background: #ddd;
+  }
+
+  .prev-month {
+    opacity: .5;
+  }
+  .next-month {
+    opacity: .5;
+  }
+}

--- a/rails/app/views/calendars/index.html.erb
+++ b/rails/app/views/calendars/index.html.erb
@@ -1,4 +1,80 @@
 <% content_for(:title, "カレンダー") %>
 
-<h1>Calendars#index</h1>
-<p>Find me in app/views/calendars/index.html.erb</p>
+<%= month_calendar do |date| %>
+  <%= date.day %>
+<% end %>
+
+<div class="mt-5 w-50 mx-auto">
+  <dl class="mt-4">
+    <h3>勤務日数</h3>
+    <div class="d-flex">
+      <dt class="col-8">平日勤務日数</dt>
+      <dd class="col-4">4日</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">土日・祝日勤務日数</dt>
+      <dd class="col-4">4日</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">総勤務日数</dt>
+      <dd class="col-4">4日</dd>
+    </div>
+  </dl>
+  <dl class="mt-4">
+    <h3>勤務時間</h3>
+    <div class="d-flex">
+      <dt class="col-8">平日勤務時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">土日・祝日勤務時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">合計勤務時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+  </dl>
+  <dl class="mt-4">
+    <h3>残業時間</h3>
+    <div class="d-flex">
+      <dt class="col-8">平日残業時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">土日・祝日残業時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">合計残業時間</dt>
+      <dd class="col-4">16時間</dd>
+    </div>
+  </dl>
+  <dl class="mt-4">
+    <h3>支給額</h3>
+    <div class="d-flex">
+      <dt class="col-8">平日支給額</dt>
+      <dd class="col-4">16000円</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">土日・祝日支給額</dt>
+      <dd class="col-4">16000円</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">特別日支給額</dt>
+      <dd class="col-4">0円</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">特別日手当</dt>
+      <dd class="col-4">0円</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">交通費</dt>
+      <dd class="col-4">300円</dd>
+    </div>
+    <div class="d-flex">
+      <dt class="col-8">総支給額</dt>
+      <dd class="col-4">36800円</dd>
+    </div>
+  </dl>
+</div>

--- a/rails/app/views/simple_calendar/_calendar.html.erb
+++ b/rails/app/views/simple_calendar/_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <%= content_tag :tr, class: calendar.tr_classes_for(week) do %>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/rails/app/views/simple_calendar/_month_calendar.html.erb
+++ b/rails/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,0 +1,33 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/rails/app/views/simple_calendar/_month_calendar.html.erb
+++ b/rails/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,19 +1,22 @@
 <div class="simple-calendar">
-  <div class="calendar-heading">
-    <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></time>
-
-    <nav>
-      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
-      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
-      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+  <div class="calendar-heading text-center">
+    <nav class="fw-bold fs-4">
+      <%= start_date.year %>年
+      <div class="fs-3">
+        <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+        <time datetime="<%= start_date.strftime('%Y-%m') %>" class="calendar-title">
+          <%= t('date.month_names')[start_date.month] %>
+        </time>
+        <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+      </div>
     </nav>
   </div>
 
-  <table class="table table-striped">
+  <table class="table mt-3">
     <thead>
       <tr>
         <% date_range.slice(0, 7).each do |day| %>
-          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+          <th class="bg-black text-white"><%= t('date.abbr_day_names')[day.wday] %></th>
         <% end %>
       </tr>
     </thead>

--- a/rails/app/views/simple_calendar/_week_calendar.html.erb
+++ b/rails/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,0 +1,39 @@
+<div class="simple-calendar">
+  <div class="calendar-heading">
+    <span class="calendar-title">
+      <%= t('simple_calendar.week', default: 'Week') %>
+      <%= calendar.week_number %>
+      <% if calendar.number_of_weeks > 1 %>
+        - <%= calendar.end_week %>
+      <% end %>
+    </span>
+
+    <nav>
+      <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
+      <%= link_to t('simple_calendar.today', default: 'Today'), calendar.url_for_today_view %>
+      <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
+    </nav>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <% date_range.slice(0, 7).each do |day| %>
+          <th><%= t('date.abbr_day_names')[day.wday] %></th>
+        <% end %>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% date_range.each_slice(7) do |week| %>
+        <tr>
+          <% week.each do |day| %>
+            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
+              <% instance_exec(day, calendar.sorted_events_for(day), &passed_block) %>
+            <% end %>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/rails/config/locales/ja.yml
+++ b/rails/config/locales/ja.yml
@@ -194,3 +194,6 @@ ja:
       truncate: "&hellip;"
   common:
     save: '保存'
+  simple_calendar:
+    previous: "<<"
+    next: ">>"


### PR DESCRIPTION
行ったこと
- simple_calendarのgemをインストール
- 月のカレンダーを表示
- カレンダーの下に勤務日数、勤務時間、残業時間、支給額の仮の情報を表示

懸念点
- 年間のカレンダーの表示
- 祝日の表示
- 出勤した日付の色の表示を変える
- カレンダーへのリンクをどうするか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - シンプルカレンダー機能を追加しました。
  - カレンダーの表示とナビゲーション機能を提供するテンプレートを導入しました。

- **スタイル**
  - カレンダーのスタイルを追加しました。
  - カレンダーの現在の日付、前月の日付、次月の日付を強調表示するスタイルを定義しました。

- **ドキュメント**
  - カレンダー表示のための日本語翻訳を追加しました（「前へ」「次へ」ボタン）。

- **ビューの改善**
  - カレンダーの詳細表示とさまざまな統計情報のレイアウトを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->