### PR TITLE
月毎の出勤データの集計を表示する機能作成

### DIFF
--- a/rails/app/controllers/attendances_controller.rb
+++ b/rails/app/controllers/attendances_controller.rb
@@ -3,7 +3,10 @@ class AttendancesController < ApplicationController
   before_action :set_attendance, only: [:show, :clock_in, :clock_out]
 
   def index
-    @attended_dates = current_user.attendances.pluck(:date).map(&:to_date).uniq
+    @attended_dates = current_user.attended_dates
+    target_month = AttendanceSummaryService.calculate_target_month(params[:start_date])
+    @attendance_summary = AttendanceSummaryService.new(current_user, target_month)
+    @start_date, @end_date = @attendance_summary.pay_period
   end
 
   def show

--- a/rails/app/helpers/application_helper.rb
+++ b/rails/app/helpers/application_helper.rb
@@ -33,6 +33,10 @@ module ApplicationHelper
     time.strftime("%H:%M") if time.present?
   end
 
+  def format_date(date)
+    date.to_date.strftime("%-m/%-d")
+  end
+
   def convert_minutes_to_hour(minutes)
     hours = minutes / 60
     minutes %= 60

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
   def full_name
     last_name + first_name
   end
+
+  def attended_dates
+    attendances.where.not(clock_out_time: nil).pluck(:date).map(&:to_date).uniq
+  end
 end

--- a/rails/app/services/attendance_summary_service.rb
+++ b/rails/app/services/attendance_summary_service.rb
@@ -1,0 +1,118 @@
+class AttendanceSummaryService
+  attr_reader :start_date, :end_date
+
+  def self.calculate_target_month(start_date_param)
+    start_date = start_date_param.present? ? Date.parse(start_date_param) : Time.zone.today
+    start_date.beginning_of_month
+  end
+
+  def initialize(user, target_month)
+    @user = user
+    @start_date, @end_date = calculate_pay_period(target_month)
+  end
+
+  def total_monthly_working_weekdays
+    weekday_attendances.count
+  end
+
+  def total_monthly_working_weekends
+    weekend_attendances.count
+  end
+
+  def total_monthly_working_days
+    attendances.count
+  end
+
+  def total_monthly_weekday_working_minutes
+    calculate_total_minutes(weekday_attendances, :working_minutes)
+  end
+
+  def total_monthly_weekend_working_minutes
+    calculate_total_minutes(weekend_attendances, :working_minutes)
+  end
+
+  def total_monthly_working_minutes
+    total_monthly_weekday_working_minutes + total_monthly_weekend_working_minutes
+  end
+
+  def total_monthly_weekday_overtime_minutes
+    calculate_total_minutes(weekday_attendances, :overtime_minutes)
+  end
+
+  def total_monthly_weekend_overtime_minutes
+    calculate_total_minutes(weekend_attendances, :overtime_minutes)
+  end
+
+  def total_monthly_overtime_minutes
+    total_monthly_weekday_overtime_minutes + total_monthly_weekend_overtime_minutes
+  end
+
+  def total_monthly_weekday_daily_wage
+    calculate_total_wage(weekday_attendances, :daily_wage)
+  end
+
+  def total_monthly_weekend_daily_wage
+    calculate_total_wage(weekend_attendances, :daily_wage)
+  end
+
+  def total_monthly_daily_wage
+    total_monthly_weekday_daily_wage + total_monthly_weekend_daily_wage
+  end
+
+  def total_monthly_weekday_overtime_pay
+    calculate_total_wage(weekday_attendances, :overtime_pay)
+  end
+
+  def total_monthly_weekend_overtime_pay
+    calculate_total_wage(weekend_attendances, :overtime_pay)
+  end
+
+  def total_monthly_overtime_pay
+    total_monthly_weekday_overtime_pay + total_monthly_weekend_overtime_pay
+  end
+
+  def total_monthly_transport_cost
+    TRANSPORT_COST * total_monthly_working_days
+  end
+
+  def total_monthly_payment
+    total_monthly_daily_wage + total_monthly_overtime_pay + total_monthly_transport_cost
+  end
+
+  def pay_period
+    [@start_date, @end_date]
+  end
+
+  private
+
+    def attendances
+      @attendances ||= @user.attendances.
+                         where(date: @start_date..@end_date).
+                         where.not(clock_out_time: nil)
+    end
+
+    def weekday_attendances
+      @weekday_attendances ||= attendances.where.not("extract(dow from date) in (?)", [0, 6])
+    end
+
+    def weekend_attendances
+      @weekend_attendances ||= attendances.where("extract(dow from date) in (?)", [0, 6])
+    end
+
+    def calculate_pay_period(target_month)
+      year = target_month.year
+      month = target_month.month
+
+      start_date = Date.new(year, month, 21) - 1.month
+      end_date = Date.new(year, month, 20)
+      [start_date, end_date]
+    end
+
+    def calculate_total_minutes(attendances, method)
+      attendances.sum {|attendance| attendance.public_send(method) }
+    end
+
+    def calculate_total_wage(attendances, method)
+      attendances.sum {|attendance| attendance.public_send(method) }
+    end
+end

--- a/rails/app/views/attendances/index.html.erb
+++ b/rails/app/views/attendances/index.html.erb
@@ -7,76 +7,107 @@
 <% end %>
 
 <div class="mt-5 w-50 mx-auto">
+  <div class="mt-4 fs-3 fw-bold">
+    <%= format_date(@start_date) %>
+    ~
+    <%= format_date(@end_date) %>
+  </div>
+
   <dl class="mt-4">
     <h3>勤務日数</h3>
     <div class="d-flex">
       <dt class="col-8">平日勤務日数</dt>
-      <dd class="col-4">4日</dd>
+      <dd class="col-4"><%= @attendance_summary.total_monthly_working_weekdays %>日</dd>
     </div>
     <div class="d-flex">
       <dt class="col-8">土日・祝日勤務日数</dt>
-      <dd class="col-4">4日</dd>
+      <dd class="col-4"><%= @attendance_summary.total_monthly_working_weekends %>日</dd>
     </div>
     <div class="d-flex">
-      <dt class="col-8">総勤務日数</dt>
-      <dd class="col-4">4日</dd>
+      <dt class="col-8">合計勤務日数</dt>
+      <dd class="col-4"><%= @attendance_summary.total_monthly_working_days %>日</dd>
     </div>
   </dl>
   <dl class="mt-4">
     <h3>勤務時間</h3>
     <div class="d-flex">
       <dt class="col-8">平日勤務時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_weekday_working_minutes) %></dd>
     </div>
     <div class="d-flex">
       <dt class="col-8">土日・祝日勤務時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_weekend_working_minutes) %></dd>
     </div>
     <div class="d-flex">
       <dt class="col-8">合計勤務時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_working_minutes) %></dd>
     </div>
   </dl>
   <dl class="mt-4">
     <h3>残業時間</h3>
     <div class="d-flex">
       <dt class="col-8">平日残業時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_weekday_overtime_minutes) %></dd>
     </div>
     <div class="d-flex">
       <dt class="col-8">土日・祝日残業時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_weekend_overtime_minutes) %></dd>
     </div>
     <div class="d-flex">
       <dt class="col-8">合計残業時間</dt>
-      <dd class="col-4">16時間</dd>
+      <dd class="col-4"><%= convert_minutes_to_hour(@attendance_summary.total_monthly_overtime_minutes) %></dd>
     </div>
   </dl>
   <dl class="mt-4">
-    <h3>支給額</h3>
-    <div class="d-flex">
-      <dt class="col-8">平日支給額</dt>
-      <dd class="col-4">16000円</dd>
+    <h3>基本給</h3>
+    <div class="mt-2">
+      <div class="d-flex">
+        <dt class="col-8">平日基本給</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_weekday_daily_wage) %></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">土日・祝日基本給</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_weekend_daily_wage) %></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">合計基本給</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_daily_wage) %></dd>
+      </div>
     </div>
-    <div class="d-flex">
-      <dt class="col-8">土日・祝日支給額</dt>
-      <dd class="col-4">16000円</dd>
+    <div class="mt-4">
+      <h3>残業代</h3>
+      <div class="d-flex">
+        <dt class="col-8">平日残業代</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_weekday_overtime_pay) %></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">土日・祝日残業代</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_weekend_overtime_pay) %></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">合計残業代</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_overtime_pay) %></dd>
+      </div>
     </div>
-    <div class="d-flex">
-      <dt class="col-8">特別日支給額</dt>
-      <dd class="col-4">0円</dd>
+    <div class="mt-4">
+      <div class="d-flex">
+        <dt class="col-8">特別日支給額</dt>
+        <dd class="col-4"></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">特別日手当</dt>
+        <dd class="col-4"></dd>
+      </div>
+      <div class="d-flex">
+        <dt class="col-8">交通費</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_transport_cost) %></dd>
+      </div>
     </div>
-    <div class="d-flex">
-      <dt class="col-8">特別日手当</dt>
-      <dd class="col-4">0円</dd>
-    </div>
-    <div class="d-flex">
-      <dt class="col-8">交通費</dt>
-      <dd class="col-4">300円</dd>
-    </div>
-    <div class="d-flex">
-      <dt class="col-8">総支給額</dt>
-      <dd class="col-4">36800円</dd>
+    <div class="mt-4">
+      <div class="d-flex">
+        <dt class="col-8">総支給額</dt>
+        <dd class="col-4"><%= number_to_currency(@attendance_summary.total_monthly_payment) %></dd>
+      </div>
     </div>
   </dl>
 </div>

--- a/rails/app/views/attendances/show.html.erb
+++ b/rails/app/views/attendances/show.html.erb
@@ -14,70 +14,76 @@
     <% end %>
   </div>
   
-  <div class="mt-5">
-    <dl class="">
-      <div class="d-flex">
-        <dt class="col-6">出勤時間</dt>
-        <dd class="col-6"><%= format_time_only(@attendance.clock_in_time) %></dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">退勤時間</dt>
-        <dd class="col-6"><%= format_time_only(@attendance.clock_out_time) %></dd>
-      </div>
-    </dl>
-    <dl class="">
-      <div class="d-flex">
-        <dt class="col-6">勤務時間</dt>
-        <dd class="col-6"><%= convert_minutes_to_hour(@attendance.working_minutes) %></dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">残業時間</dt>
-        <dd class="col-6"><%= convert_minutes_to_hour(@attendance.overtime_minutes) %></dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">総勤務時間</dt>
-        <dd class="col-6"><%= convert_minutes_to_hour(@attendance.total_working_minutes) %></dd>
-      </div>
-    </dl>
-    <dl class="">
-      <div class="d-flex">
-        <dt class="col-6">時給</dt>
-        <dd class="col-6">
-          <%= number_to_currency(@attendance.hourly_wage) %>
-        </dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">支給額</dt>
-        <dd class="col-6">
-          <%= number_to_currency(@attendance.daily_wage) %>
-        </dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">残業代</dt>
-        <dd class="col-6">
-          <%= number_to_currency(@attendance.overtime_pay) %>
-        </dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">交通費</dt>
-        <dd class="col-6">
-          <%= number_to_currency(TRANSPORT_COST) %>
-        </dd>
-      </div>
-      <div class="d-flex">
-        <dt class="col-6">特別日手当</dt>
-        <dd class="col-6">
-          <%= number_to_currency(@attendance.allowance) %>
-        </dd>
-      </div>
-    </dl>
-    <dl class="">
-      <div class="d-flex">
-        <dt class="col-6">総支給額</dt>
-        <dd class="col-6">
-          <%= number_to_currency(@attendance.total_payment) %>
-        </dd>
-      </div>
-    </dl>
-  </div>
+  <% if @attendance.clock_in_time.present? %>
+    <div class="mt-5">
+      <dl class="">
+        <div class="d-flex">
+          <dt class="col-6">出勤時間</dt>
+          <dd class="col-6"><%= format_time_only(@attendance.clock_in_time) %></dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">退勤時間</dt>
+          <dd class="col-6"><%= format_time_only(@attendance.clock_out_time) %></dd>
+        </div>
+      </dl>
+      <dl class="">
+        <div class="d-flex">
+          <dt class="col-6">勤務時間</dt>
+          <dd class="col-6"><%= convert_minutes_to_hour(@attendance.working_minutes) %></dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">残業時間</dt>
+          <dd class="col-6"><%= convert_minutes_to_hour(@attendance.overtime_minutes) %></dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">総勤務時間</dt>
+          <dd class="col-6"><%= convert_minutes_to_hour(@attendance.total_working_minutes) %></dd>
+        </div>
+      </dl>
+      <dl class="">
+        <div class="d-flex">
+          <dt class="col-6">時給</dt>
+          <dd class="col-6">
+            <%= number_to_currency(@attendance.hourly_wage) %>
+          </dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">支給額</dt>
+          <dd class="col-6">
+            <%= number_to_currency(@attendance.daily_wage) %>
+          </dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">残業代</dt>
+          <dd class="col-6">
+            <%= number_to_currency(@attendance.overtime_pay) %>
+          </dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">交通費</dt>
+          <dd class="col-6">
+            <%= number_to_currency(TRANSPORT_COST) %>
+          </dd>
+        </div>
+        <div class="d-flex">
+          <dt class="col-6">特別日手当</dt>
+          <dd class="col-6">
+            <%= number_to_currency(@attendance.allowance) %>
+          </dd>
+        </div>
+      </dl>
+      <dl class="">
+        <div class="d-flex">
+          <dt class="col-6">総支給額</dt>
+          <dd class="col-6">
+            <%= number_to_currency(@attendance.total_payment) %>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  <% else %>
+    <div class="mt-5 text-center">
+      <p class="fs-3">出勤データがありません</p>
+    </div>
+  <% end %>
 </div>

--- a/rails/config/environments/development.rb
+++ b/rails/config/environments/development.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Show full error reports.
-  config.consider_all_requests_local = false
+  config.consider_all_requests_local = true
 
   # Enable server timing
   config.server_timing = true

--- a/rails/spec/services/attendance_summary_service_spec.rb
+++ b/rails/spec/services/attendance_summary_service_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe AttendanceSummaryService, type: :service do
+  let!(:user) { create(:user) }
+  let(:service) { AttendanceSummaryService.new(user, target_month) }
+  let!(:target_month) { Date.new(2024, 5, 1) }
+  let!(:start_date) { Date.new(2024, 4, 21) }
+  let!(:end_date) { Date.new(2024, 5, 20) }
+  let!(:transport_cost) { 320 }
+
+  def create_weekday_attendance(user)
+    create(:attendance, user:, date: start_date + 1.day, working_minutes: 240, overtime_minutes: 0, daily_wage: 4000, overtime_pay: 0) # 2024-04-22 (月曜日)
+    create(:attendance, user:, date: start_date + 2.days, working_minutes: 240, overtime_minutes: 60, daily_wage: 4000, overtime_pay: 1000) # 2024-04-23 (火曜日)
+  end
+
+  def create_weekend_attendance(user)
+    create(:attendance, user:, date: start_date + 6.days, working_minutes: 240, overtime_minutes: 0, daily_wage: 4400, overtime_pay: 0) # 2024-04-27 (土曜日)
+    create(:attendance, user:, date: start_date + 7.days, working_minutes: 240, overtime_minutes: 60, daily_wage: 4400, overtime_pay: 1100) # 2024-04-28 (日曜日)
+  end
+
+  before do
+    create_weekday_attendance(user)
+    create_weekend_attendance(user)
+  end
+
+  describe "#total_monthly_working_weekdays" do
+    it "平日の合計出勤日数を返す" do
+      expect(service.total_monthly_working_weekdays).to eq(2)
+    end
+  end
+
+  describe "#total_monthly_working_weekends" do
+    it "土日の合計出勤日数を返す" do
+      expect(service.total_monthly_working_weekends).to eq(2)
+    end
+  end
+
+  describe "#total_monthly_working_days" do
+    it "合計出勤日数を返す" do
+      expect(service.total_monthly_working_days).to eq(4)
+    end
+  end
+
+  describe "#total_monthly_weekday_working_minutes" do
+    it "平日の合計出勤時間を返す" do
+      expect(service.total_monthly_weekday_working_minutes).to eq(480)
+    end
+  end
+
+  describe "#total_monthly_weekend_working_minutes" do
+    it "土日の合計出勤時間を返す" do
+      expect(service.total_monthly_weekend_working_minutes).to eq(480)
+    end
+  end
+
+  describe "#total_monthly_working_minutes" do
+    it "合計出勤時間を返す" do
+      expect(service.total_monthly_working_minutes).to eq(960)
+    end
+  end
+
+  describe "#total_monthly_weekday_overtime_minutes" do
+    it "平日の合計残業時間を返す" do
+      expect(service.total_monthly_weekday_overtime_minutes).to eq(60)
+    end
+  end
+
+  describe "#total_monthly_weekend_overtime_minutes" do
+    it "土日の合計残業時間を返す" do
+      expect(service.total_monthly_weekend_overtime_minutes).to eq(60)
+    end
+  end
+
+  describe "#total_monthly_overtime_minutes" do
+    it "合計残業時間を返す" do
+      expect(service.total_monthly_overtime_minutes).to eq(120)
+    end
+  end
+
+  describe "#total_monthly_weekday_daily_wage" do
+    it "平日の合計基本給を返す" do
+      expect(service.total_monthly_weekday_daily_wage).to eq(8000)
+    end
+  end
+
+  describe "#total_monthly_weekend_daily_wage" do
+    it "土日の合計基本給を返す" do
+      expect(service.total_monthly_weekend_daily_wage).to eq(8800)
+    end
+  end
+
+  describe "#total_monthly_daily_wage" do
+    it "合計基本給を返す" do
+      expect(service.total_monthly_daily_wage).to eq(16800)
+    end
+  end
+
+  describe "#total_monthly_weekday_overtime_pay" do
+    it "平日の合計残業代を返す" do
+      expect(service.total_monthly_weekday_overtime_pay).to eq(1000)
+    end
+  end
+
+  describe "#total_monthly_weekend_overtime_pay" do
+    it "土日の合計残業代を返す" do
+      expect(service.total_monthly_weekend_overtime_pay).to eq(1100)
+    end
+  end
+
+  describe "#total_monthly_overtime_pay" do
+    it "合計残業代を返す" do
+      expect(service.total_monthly_overtime_pay).to eq(2100)
+    end
+  end
+
+  describe "#total_monthly_transport_cost" do
+    it "合計交通費を返す" do
+      expect(service.total_monthly_transport_cost).to eq(transport_cost * 4)
+    end
+  end
+
+  describe "#total_monthly_payment" do
+    it "総支給額を返す" do
+      expect(service.total_monthly_payment).to eq(20180)
+    end
+  end
+end


### PR DESCRIPTION
行ったこと
- 月毎の出勤データの計算を行うサービスクラスを作成
- カレンダーページに月毎の出勤データを表示する
- 勤怠詳細ページでデータがない場合は表示しないようにするように修正
- サービスクラスのスペックを作成
- 出勤データの表示のシステムスペックを作成

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 出勤状況と給与の計算を行う新しい`AttendanceSummaryService`クラスを導入しました。

- **バグ修正**
  - 出勤日を取得するメソッドを最適化し、`current_user.attended_dates`を使用するように変更しました。
  - `@attendance_summary`オブジェクトから動的にデータを取得するように出勤状況の表示を更新しました。

- **ドキュメント**
  - 出勤日をフォーマットする新しいヘルパーメソッド`format_date(date)`を追加しました。

- **テスト**
  - `AttendanceSummaryService`クラスに関連する計算を検証するテストを追加しました。
  - 平日と週末の出勤記録を作成するための新しいテストメソッドを追加しました。

- **設定変更**
  - 開発環境でエラーレポートを詳細に表示するように設定を変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->