### PR TITLE
管理勤怠一覧機能作成

### DIFF
--- a/rails/app/controllers/admins/attendances_controller.rb
+++ b/rails/app/controllers/admins/attendances_controller.rb
@@ -1,0 +1,5 @@
+class Admins::AttendancesController < Admins::BaseController
+  def index
+    @attendances = Attendance.preload(:user).page(params[:page]).order("created_at DESC")
+  end
+end

--- a/rails/app/controllers/admins/base_controller.rb
+++ b/rails/app/controllers/admins/base_controller.rb
@@ -5,6 +5,6 @@ class Admins::BaseController < ApplicationController
   private
 
     def authenticate_admin!
-      redirect_to new_admin_session_path unless current_admin
+      redirect_to new_admin_session_url unless current_admin
     end
 end

--- a/rails/app/controllers/admins/special_days_controller.rb
+++ b/rails/app/controllers/admins/special_days_controller.rb
@@ -12,7 +12,7 @@ class Admins::SpecialDaysController < Admins::BaseController
   def create
     @special_day = SpecialDay.new(special_day_params)
     if @special_day.save
-      redirect_to admins_special_days_path, notice: "特別日が作成されました"
+      redirect_to admins_special_days_url, notice: "特別日が作成されました"
     else
       render :new, status: :unprocessable_entity
     end
@@ -22,7 +22,7 @@ class Admins::SpecialDaysController < Admins::BaseController
     @special_day = SpecialDay.find(params[:id])
     @special_day.destroy!
 
-    redirect_to admins_special_days_path, notice: "特別日を削除しました", status: :see_other
+    redirect_to admins_special_days_url, notice: "特別日を削除しました", status: :see_other
   end
 
   private

--- a/rails/app/controllers/admins/users_controller.rb
+++ b/rails/app/controllers/admins/users_controller.rb
@@ -13,7 +13,7 @@ class Admins::UsersController < Admins::BaseController
 
   def update
     if @user.wage.update(wage_params)
-      redirect_to admins_users_path, notice: "ユーザー情報を更新しました"
+      redirect_to admins_users_url, notice: "ユーザー情報を更新しました"
     else
       render :edit, status: :unprocessable_entity
     end
@@ -22,7 +22,7 @@ class Admins::UsersController < Admins::BaseController
   def destroy
     @user.destroy!
 
-    redirect_to admins_users_path, notice: "ユーザーを削除しました", status: :see_other
+    redirect_to admins_users_url, notice: "ユーザーを削除しました", status: :see_other
   end
 
   private

--- a/rails/app/controllers/attendances_controller.rb
+++ b/rails/app/controllers/attendances_controller.rb
@@ -30,6 +30,8 @@ class AttendancesController < ApplicationController
 
     def set_attendance
       @date = Date.parse(params[:date])
-      @attendance = Attendance.find_or_initialize_by(user_id: current_user.id, date: @date)
+      @special_day = SpecialDay.for_date(@date)
+      @attendance = Attendance.find_or_initialize_by(user_id: current_user.id, date: @date, special_day: @special_day.present?)
+      logger.debug @attendance.special_day
     end
 end

--- a/rails/app/decorators/attendance_decorator.rb
+++ b/rails/app/decorators/attendance_decorator.rb
@@ -7,11 +7,11 @@ class AttendanceDecorator < ApplicationDecorator
 
   def can_clock_in?
     current_time = Time.current
-    current_time >= Time.current.change(hour: 9, min: 30) && object.clock_in_time.blank?
+    current_time >= Time.current.change(hour: 9, min: 30) && object.clock_in_time.nil?
   end
 
   def can_clock_out?
-    object.clock_in_time.present? && object.clock_out_time.blank?
+    object.clock_in_time.present? && object.clock_out_time.nil?
   end
 
   def day_of_week(date)

--- a/rails/app/models/attendance.rb
+++ b/rails/app/models/attendance.rb
@@ -19,7 +19,7 @@ class Attendance < ApplicationRecord
   end
 
   def fetch_special_day
-    @special_day ||= SpecialDay.for_date(date)
+    @fetch_special_day ||= SpecialDay.for_date(date)
   end
 
   def special_day?

--- a/rails/app/models/attendance.rb
+++ b/rails/app/models/attendance.rb
@@ -4,9 +4,6 @@ class Attendance < ApplicationRecord
   GUARANTEED_WAGE_MINUTES = 240
   OVERTIME_INTERVAL_MINUTES = 30
 
-  after_initialize :initialize_special_day
-  after_save :check_and_update_special_day, if: :saved_change_to_clock_in_time?
-
   def update_attendance_data
     update(
       working_minutes: calculate_working_minutes,
@@ -21,23 +18,15 @@ class Attendance < ApplicationRecord
     )
   end
 
+  def fetch_special_day
+    @special_day ||= SpecialDay.for_date(date)
+  end
+
   def special_day?
-    self.special_day.present?
+    fetch_special_day.present?
   end
 
   private
-
-    def initialize_special_day
-      @special_day = find_special_day
-    end
-
-    def find_special_day
-      SpecialDay.find_by(["start_date <= ? AND end_date >= ?", date, date])
-    end
-
-    def check_and_update_special_day
-      update!(special_day: true) if special_day?
-    end
 
     def calculate_working_minutes
       total_working_minutes = calculate_total_working_minutes
@@ -55,7 +44,7 @@ class Attendance < ApplicationRecord
 
     def set_hourly_wage
       base_wage = weekend? ? user.wage.weekend_hourly_wage : user.wage.weekday_hourly_wage
-      base_wage += special_day.wage_increment if special_day?
+      base_wage += fetch_special_day.wage_increment if special_day?
       base_wage
     end
 
@@ -74,7 +63,7 @@ class Attendance < ApplicationRecord
     end
 
     def set_allowance
-      special_day? ? special_day.allowance : allowance
+      special_day? ? fetch_special_day.allowance : allowance
     end
 
     def calculate_daily_total_payment

--- a/rails/app/models/special_day.rb
+++ b/rails/app/models/special_day.rb
@@ -7,6 +7,10 @@ class SpecialDay < ApplicationRecord
   validate :start_date_before_end_date
   validate :no_overlapping_dates
 
+  def self.for_date(date)
+    find_by("start_date <= ? AND end_date >= ?", date, date)
+  end
+
   def self.in_month(date)
     start_date = date.beginning_of_month
     end_date = date.end_of_month

--- a/rails/app/views/admins/attendances/index.html.erb
+++ b/rails/app/views/admins/attendances/index.html.erb
@@ -1,0 +1,55 @@
+<% content_for(:title, "管理勤怠一覧") %>
+
+<div class="col-md-10 mx-auto">
+  <div class="d-flex justify-content-between align-items-center">
+    <h2 class="fw-bold">管理勤怠一覧</h2>
+    <div class="">
+      <span class="fs-2 fw-bold">
+        <%= @attendances.total_count %>
+      </span>
+      件中
+      <span class="fs-2 fw-bold">
+        <%= @attendances.offset_value %>
+      </span>
+      〜
+      <span class="fs-2 fw-bold">
+        <%= @attendances.offset_value + @attendances.length %>
+      </span>
+      件
+    </div>
+  </div>
+  
+  <table class="table">
+    <thead>
+      <tr>
+        <th class="col-1">No</th>
+        <th class="col-2">名前</th>
+        <th class="col-2">日付</th>
+        <th class="col-2">出勤時刻</th>
+        <th class="col-2">退勤時刻</th>
+        <th class="col-1"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @attendances.each do |attendance| %>
+        <tr>
+          <td class="align-middle col-1"><%= attendance.id %></td>
+          <td class="align-middle col-2"><%= attendance.user.full_name %></td>
+          <td class="align-middle col-2"><%= attendance.date %></td>
+          <td class="align-middle col-2"><%= format_time_only(attendance.clock_in_time) %></td>
+          <td class="align-middle col-2"><%= format_time_only(attendance.clock_out_time) %></td>
+          <td class="align-middle col-1">
+            <%= link_to "#", class: 'btn btn-success' do %>
+              <i class="bi bi-pencil-square"></i>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <div class="mt-5 d-flex justify-content-center">
+    <%= paginate @attendances, theme: 'bootstrap-5' %>
+  </div>
+
+</div>

--- a/rails/app/views/attendances/show.html.erb
+++ b/rails/app/views/attendances/show.html.erb
@@ -4,7 +4,7 @@
   <div class="text-center">
     <div class="fs-4">
       <p><%= @attendance.date.strftime("%Y年%m月%d日") %> <%= @attendance.decorate.day_of_week(@date) %></p>
-      <p><%= @attendance.special_day? ? "（特別日）" : "" %></p>
+      <p><%= @special_day ? "#{@special_day.description}（特別日）" : "" %></p>
     </div>
     <% if @attendance.decorate.today? %>
       <div class="clock fs-1"></div>

--- a/rails/app/views/layouts/admin.html.erb
+++ b/rails/app/views/layouts/admin.html.erb
@@ -21,7 +21,7 @@
         </li>
         <li class="list-group-item">
           <span class="ms-3">
-            勤怠管理
+            <%= link_to "勤怠管理", admins_attendances_path %>
           </span>
         </li>
         <li class="list-group-item">

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     passwords: "users/passwords",
     registrations: "users/registrations",
     confirmations: "users/confirmations",
-  }, path: 'users'
+  }, path: "users"
 
   resources :attendances, only: [:index, :new] do
     collection do
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
 
   devise_for :admins, controllers: {
     sessions: "admins/sessions",
-  }, path: 'admins'
+  }, path: "admins"
 
   namespace :admins do
     root to: "dashboard#index"

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
     passwords: "users/passwords",
     registrations: "users/registrations",
     confirmations: "users/confirmations",
-  }
+  }, path: 'users'
 
   resources :attendances, only: [:index, :new] do
     collection do
@@ -18,12 +18,13 @@ Rails.application.routes.draw do
 
   devise_for :admins, controllers: {
     sessions: "admins/sessions",
-  }
+  }, path: 'admins'
 
   namespace :admins do
     root to: "dashboard#index"
     resources :users, only: [:index, :edit, :update, :destroy]
     resources :special_days, only: [:index, :new, :create, :destroy]
+    resources :attendances, only: [:index]
   end
 
   root to: "attendances#index"

--- a/rails/spec/models/attendance_spec.rb
+++ b/rails/spec/models/attendance_spec.rb
@@ -87,19 +87,39 @@ RSpec.describe Attendance, type: :model do
     end
   end
 
-  describe "#special_day?" do
-    context "出勤日が特別日の場合" do
-      let!(:attendance) { build(:attendance, user:, special_day: true) }
+  describe '#fetch_special_day' do
+    let!(:date) { Date.current }
+    let!(:attendance) { create(:attendance, user:, date: date) }
 
-      it "trueを返す" do
+    context '特別日が存在する場合' do
+      let!(:special_day) { create(:special_day, start_date: date, end_date: date) }
+      
+      it '特別日を取得できる' do
+        expect(attendance.fetch_special_day).to eq(special_day)
+      end
+    end
+
+    context '特別日が存在しない場合' do
+      it 'nilを返す' do
+        expect(attendance.fetch_special_day).to be_nil
+      end
+    end
+  end
+
+  describe '#special_day?' do
+    let!(:date) { Date.current }
+    let!(:attendance) { create(:attendance, user:, date: date) }
+
+    context '特別日が存在する場合' do
+      let!(:special_day) { create(:special_day, start_date: date, end_date: date) }
+
+      it 'trueを返す' do
         expect(attendance.special_day?).to be true
       end
     end
 
-    context "出勤日が特別日ではない場合" do
-      let!(:attendance) { build(:attendance, user:, special_day: false) }
-
-      it "falseを返す" do
+    context '特別日が存在しない場合' do
+      it 'falseを返す' do
         expect(attendance.special_day?).to be false
       end
     end

--- a/rails/spec/models/attendance_spec.rb
+++ b/rails/spec/models/attendance_spec.rb
@@ -87,39 +87,39 @@ RSpec.describe Attendance, type: :model do
     end
   end
 
-  describe '#fetch_special_day' do
+  describe "#fetch_special_day" do
     let!(:date) { Date.current }
-    let!(:attendance) { create(:attendance, user:, date: date) }
+    let!(:attendance) { create(:attendance, user:, date:) }
 
-    context '特別日が存在する場合' do
+    context "特別日が存在する場合" do
       let!(:special_day) { create(:special_day, start_date: date, end_date: date) }
-      
-      it '特別日を取得できる' do
+
+      it "特別日を取得できる" do
         expect(attendance.fetch_special_day).to eq(special_day)
       end
     end
 
-    context '特別日が存在しない場合' do
-      it 'nilを返す' do
+    context "特別日が存在しない場合" do
+      it "nilを返す" do
         expect(attendance.fetch_special_day).to be_nil
       end
     end
   end
 
-  describe '#special_day?' do
+  describe "#special_day?" do
     let!(:date) { Date.current }
-    let!(:attendance) { create(:attendance, user:, date: date) }
+    let!(:attendance) { create(:attendance, user:, date:) }
 
-    context '特別日が存在する場合' do
+    context "特別日が存在する場合" do
       let!(:special_day) { create(:special_day, start_date: date, end_date: date) }
 
-      it 'trueを返す' do
+      it "trueを返す" do
         expect(attendance.special_day?).to be true
       end
     end
 
-    context '特別日が存在しない場合' do
-      it 'falseを返す' do
+    context "特別日が存在しない場合" do
+      it "falseを返す" do
         expect(attendance.special_day?).to be false
       end
     end

--- a/rails/spec/system/admins/attendances_spec.rb
+++ b/rails/spec/system/admins/attendances_spec.rb
@@ -39,38 +39,38 @@ RSpec.describe "Admins::Attendances", type: :system do
       it "2ページ目への移動が成功する" do
         visit admins_attendances_path
         click_link "2"
-        expect(page).to have_current_path(admins_attendances_path(page: 2))
+        expect(page).to have_current_path admins_attendances_path(page: 2)
       end
 
       it "次のページへの移動が成功する" do
         visit admins_attendances_path
         click_link "›"
-        expect(page).to have_current_path(admins_attendances_path(page: 2))
+        expect(page).to have_current_path admins_attendances_path(page: 2)
       end
 
       it "最後のページへの移動が成功する" do
         visit admins_attendances_path
         click_link "»"
-        expect(page).to have_current_path(admins_attendances_path(page: 10))
+        expect(page).to have_current_path admins_attendances_path(page: 10)
       end
 
       it "前のページへの移動が成功する" do
         visit admins_attendances_path(page: 2)
         click_link "‹"
-        expect(page).to have_current_path(admins_attendances_path)
+        expect(page).to have_current_path admins_attendances_path
       end
 
       it "最初のページへの移動が成功する" do
         visit admins_attendances_path(page: 10)
         click_link "«"
-        expect(page).to have_current_path(admins_attendances_path)
+        expect(page).to have_current_path admins_attendances_path
       end
     end
 
     context "管理者が未ログインの場合" do
       it "管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_attendances_path
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
 
@@ -83,7 +83,7 @@ RSpec.describe "Admins::Attendances", type: :system do
 
       it "一般ユーザーが管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_attendances_path
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
   end

--- a/rails/spec/system/admins/attendances_spec.rb
+++ b/rails/spec/system/admins/attendances_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe "Admins::Attendances", type: :system do
   end
 
   def create_users_with_attendances(count = 100)
-    count.times do |n|
+    count.times do |_n|
       user = create(:user)
       create(:attendance, user:)
     end
   end
 
-  describe '管理勤怠一覧' do
+  describe "管理勤怠一覧" do
     let!(:admin) { create(:admin, name: "admin", password: "password") }
 
-    context '管理者がログイン済みの場合' do
+    context "管理者がログイン済みの場合" do
       before do
         create_users_with_attendances(100)
 
@@ -23,7 +23,7 @@ RSpec.describe "Admins::Attendances", type: :system do
         visit admins_attendances_path
       end
 
-      it '管理勤怠一覧画面にアクセスが成功する' do
+      it "管理勤怠一覧画面にアクセスが成功する" do
         expect(page).to have_content "管理勤怠一覧"
         expect(page).to have_content "admin"
         expect(page).to have_content "ログアウト"
@@ -67,26 +67,24 @@ RSpec.describe "Admins::Attendances", type: :system do
       end
     end
 
-    context '管理者が未ログインの場合' do
-      it '管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる' do
+    context "管理者が未ログインの場合" do
+      it "管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_attendances_path
         expect(page).to have_current_path(new_admin_session_path)
       end
     end
 
-    context '一般ユーザーがログイン済みの場合' do
+    context "一般ユーザーがログイン済みの場合" do
       let!(:user) { create(:user) }
 
       before do
         sign_in user
       end
 
-      it '一般ユーザーが管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる' do
+      it "一般ユーザーが管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_attendances_path
         expect(page).to have_current_path(new_admin_session_path)
       end
     end
-
   end
-
 end

--- a/rails/spec/system/admins/attendances_spec.rb
+++ b/rails/spec/system/admins/attendances_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe "Admins::Attendances", type: :system do
+  before do
+    driven_by(:rack_test)
+  end
+
+  def create_users_with_attendances(count = 100)
+    count.times do |n|
+      user = create(:user)
+      create(:attendance, user:)
+    end
+  end
+
+  describe '管理勤怠一覧' do
+    let!(:admin) { create(:admin, name: "admin", password: "password") }
+
+    context '管理者がログイン済みの場合' do
+      before do
+        create_users_with_attendances(100)
+
+        sign_in admin
+        visit admins_attendances_path
+      end
+
+      it '管理勤怠一覧画面にアクセスが成功する' do
+        expect(page).to have_content "管理勤怠一覧"
+        expect(page).to have_content "admin"
+        expect(page).to have_content "ログアウト"
+        expect(page).to have_content "No"
+        expect(page).to have_content "名前"
+        expect(page).to have_content "日付"
+        expect(page).to have_content "出勤時刻"
+        expect(page).to have_content "退勤時刻"
+        expect(page).to have_content "100"
+        expect(page).to have_selector ".pagination"
+      end
+
+      it "2ページ目への移動が成功する" do
+        visit admins_attendances_path
+        click_link "2"
+        expect(page).to have_current_path(admins_attendances_path(page: 2))
+      end
+
+      it "次のページへの移動が成功する" do
+        visit admins_attendances_path
+        click_link "›"
+        expect(page).to have_current_path(admins_attendances_path(page: 2))
+      end
+
+      it "最後のページへの移動が成功する" do
+        visit admins_attendances_path
+        click_link "»"
+        expect(page).to have_current_path(admins_attendances_path(page: 10))
+      end
+
+      it "前のページへの移動が成功する" do
+        visit admins_attendances_path(page: 2)
+        click_link "‹"
+        expect(page).to have_current_path(admins_attendances_path)
+      end
+
+      it "最初のページへの移動が成功する" do
+        visit admins_attendances_path(page: 10)
+        click_link "«"
+        expect(page).to have_current_path(admins_attendances_path)
+      end
+    end
+
+    context '管理者が未ログインの場合' do
+      it '管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる' do
+        visit admins_attendances_path
+        expect(page).to have_current_path(new_admin_session_path)
+      end
+    end
+
+    context '一般ユーザーがログイン済みの場合' do
+      let!(:user) { create(:user) }
+
+      before do
+        sign_in user
+      end
+
+      it '一般ユーザーが管理勤怠一覧画面にアクセスすると管理ログイン画面にリダイレクトされる' do
+        visit admins_attendances_path
+        expect(page).to have_current_path(new_admin_session_path)
+      end
+    end
+
+  end
+
+end

--- a/rails/spec/system/admins/users_spec.rb
+++ b/rails/spec/system/admins/users_spec.rb
@@ -17,46 +17,46 @@ RSpec.describe "Admins::Users", type: :system do
 
       it "管理画面のユーザー一覧にアクセスが成功する" do
         visit admins_users_path
-        expect(page).to have_content("ユーザー")
-        expect(page).to have_content("100")
-        expect(page).to have_selector(".pagination")
+        expect(page).to have_content "ユーザー"
+        expect(page).to have_content "100"
+        expect(page).to have_selector ".pagination"
       end
 
       it "2ページ目への移動が成功する" do
         visit admins_users_path
         click_link "2"
-        expect(page).to have_current_path(admins_users_path(page: 2))
+        expect(page).to have_current_path admins_users_path(page: 2)
       end
 
       it "次のページへの移動が成功する" do
         visit admins_users_path
         click_link "›"
-        expect(page).to have_current_path(admins_users_path(page: 2))
+        expect(page).to have_current_path admins_users_path(page: 2)
       end
 
       it "最後のページへの移動が成功する" do
         visit admins_users_path
         click_link "»"
-        expect(page).to have_current_path(admins_users_path(page: 10))
+        expect(page).to have_current_path admins_users_path(page: 10)
       end
 
       it "前のページへの移動が成功する" do
         visit admins_users_path(page: 2)
         click_link "‹"
-        expect(page).to have_current_path(admins_users_path)
+        expect(page).to have_current_path admins_users_path
       end
 
       it "最初のページへの移動が成功する" do
         visit admins_users_path(page: 10)
         click_link "«"
-        expect(page).to have_current_path(admins_users_path)
+        expect(page).to have_current_path admins_users_path
       end
     end
 
     context "未ログインの場合" do
       it "管理画面のユーザー一覧にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_users_path
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe "Admins::Users", type: :system do
 
       it "管理画面ユーザー一覧にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit admins_users_path
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
   end
@@ -86,8 +86,8 @@ RSpec.describe "Admins::Users", type: :system do
 
       it "管理画面ユーザー編集画面にアクセスが成功する" do
         visit edit_admins_user_path(user)
-        expect(page).to have_content("平日時給")
-        expect(page).to have_content("土日・祝日時給")
+        expect(page).to have_content "平日時給"
+        expect(page).to have_content "土日・祝日時給"
         expect(page).to have_field("wage_weekday_hourly_wage", with: 1000)
         expect(page).to have_field("wage_weekend_hourly_wage", with: 1100)
       end
@@ -97,14 +97,14 @@ RSpec.describe "Admins::Users", type: :system do
         fill_in "平日時給", with: 1200
         fill_in "土日・祝日時給", with: 1300
         click_button "保存"
-        expect(page).to have_current_path(admins_users_path)
+        expect(page).to have_current_path admins_users_path
       end
     end
 
     context "未ログインの場合" do
       it "管理画面のユーザー編集画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit edit_admins_user_path(1)
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
 
@@ -117,7 +117,7 @@ RSpec.describe "Admins::Users", type: :system do
 
       it "管理画面ユーザー編集画面にアクセスすると管理ログイン画面にリダイレクトされる" do
         visit edit_admins_user_path(1)
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
   end
@@ -132,14 +132,14 @@ RSpec.describe "Admins::Users", type: :system do
 
     it "削除ボタンをクリックして確認ダイアログで削除をクリックするとユーザーの削除が成功する", js: true do
       visit edit_admins_user_path(users.first)
-      expect(page).to have_content("削除")
+      expect(page).to have_content "削除"
 
       expect {
         click_link "削除"
       }.to change { User.count }.by(-1)
 
-      expect(page).to have_current_path(admins_users_path, ignore_query: true)
-      expect(page).to have_content("ユーザーを削除しました")
+      expect(page).to have_current_path admins_users_path, ignore_query: true
+      expect(page).to have_content "ユーザーを削除しました"
     end
   end
 end

--- a/rails/spec/system/admins_spec.rb
+++ b/rails/spec/system/admins_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe "Admins", type: :system do
         click_button "ログイン"
 
         expect(Admin.find_by(name: "admin")).not_to be_nil
-        expect(page).to have_current_path(admins_root_path)
-        expect(page).to have_content("ログインしました")
-        expect(page).to have_link("ログアウト")
+        expect(page).to have_current_path admins_root_path
+        expect(page).to have_content "ログインしました"
+        expect(page).to have_link "ログアウト"
       end
 
       it "間違ったユーザー名でログインが失敗する" do
@@ -53,7 +53,7 @@ RSpec.describe "Admins", type: :system do
         fill_in_login_form(invalid_name_info)
         click_button "ログイン"
 
-        expect(page).to have_content("ユーザー名かパスワードが間違っています")
+        expect(page).to have_content "ユーザー名かパスワードが間違っています"
       end
 
       it "間違ったパスワードでログインが失敗する" do
@@ -61,7 +61,7 @@ RSpec.describe "Admins", type: :system do
         fill_in_login_form(invalid_password_info)
         click_button "ログイン"
 
-        expect(page).to have_content("ユーザー名かパスワードが間違っています")
+        expect(page).to have_content "ユーザー名かパスワードが間違っています"
       end
     end
 
@@ -75,8 +75,8 @@ RSpec.describe "Admins", type: :system do
       it "管理ユーザーログインページに遷移しようとすると管理ダッシュボードにリダイレクトされる" do
         visit new_admin_session_path
 
-        expect(page).to have_current_path(admins_root_path)
-        expect(page).to have_content("すでにログイン済みです")
+        expect(page).to have_current_path admins_root_path
+        expect(page).to have_content "すでにログイン済みです"
       end
     end
   end
@@ -93,11 +93,11 @@ RSpec.describe "Admins", type: :system do
 
     it "ログアウトが成功する" do
       click_link "ログアウト"
-      expect(page).to have_content("ログアウトしました")
-      expect(page).to have_current_path(new_admin_session_path)
-      expect(page).to have_link("ログイン")
-      expect(page).to have_link("アカウント登録")
-      expect(page).not_to have_link("ログアウト")
+      expect(page).to have_content "ログアウトしました"
+      expect(page).to have_current_path new_admin_session_path
+      expect(page).to have_link "ログイン"
+      expect(page).to have_link "アカウント登録"
+      expect(page).not_to have_link "ログアウト"
     end
   end
 end

--- a/rails/spec/system/attendances_spec.rb
+++ b/rails/spec/system/attendances_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Attendances", type: :system do
       it "ログイン画面にリダイレクトされる" do
         visit attendances_path
 
-        expect(page).to have_current_path(new_user_session_path)
+        expect(page).to have_current_path new_user_session_path
       end
     end
 
@@ -194,7 +194,7 @@ RSpec.describe "Attendances", type: :system do
       it "ログイン画面にリダイレクトされる" do
         visit date_attendances_path(attendance.date)
 
-        expect(page).to have_current_path(new_user_session_path)
+        expect(page).to have_current_path new_user_session_path
       end
     end
   end
@@ -213,7 +213,7 @@ RSpec.describe "Attendances", type: :system do
 
         click_button "出勤"
 
-        expect(page).to have_content("出勤しました")
+        expect(page).to have_content "出勤しました"
         expect(page).to have_button "出勤", disabled: true
         expect(page).to have_button "退勤"
       end

--- a/rails/spec/system/attendances_spec.rb
+++ b/rails/spec/system/attendances_spec.rb
@@ -117,12 +117,14 @@ RSpec.describe "Attendances", type: :system do
     context "ログインしている場合" do
       before do
         sign_in user
-        visit date_attendances_path(Time.current)
+        visit date_attendances_path(date: Date.current)
       end
 
       context "日付が今日の場合" do
         context "既に勤怠記録がある場合" do
-          let!(:attendance) { create(:attendance, user:, date: Date.current, clock_in_time: "10:00", clock_out_time: "14:00") }
+          let!(:attendance) {
+            create(:attendance, user:, date: Date.current, clock_in_time: Time.zone.parse("10:00"), clock_out_time: Time.zone.parse("14:00"))
+          }
 
           it "既存の勤怠記録を表示し、データベースに存在することを確認する" do
             expect(page).to have_button "出勤", disabled: true
@@ -147,9 +149,10 @@ RSpec.describe "Attendances", type: :system do
 
         context "特別日の場合" do
           let!(:special_day) { create(:special_day, start_date: Date.current, end_date: Date.current) }
-          let!(:attendance) { create(:attendance, user:, date: Date.current, special_day: true) }
+          let!(:attendance) { create(:attendance, user:, date: Date.current) }
 
           it "日付の下に特別日と表示される" do
+            visit date_attendances_path(date: Date.current)
             expect(page).to have_content "（特別日）"
           end
         end

--- a/rails/spec/system/special_days_spec.rb
+++ b/rails/spec/system/special_days_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "SpecialDays", type: :system do
       end
 
       it "特別日作成画面にアクセスが成功する" do
-        expect(page).to have_title("特別日作成")
+        expect(page).to have_title "特別日作成"
       end
 
       it "フォームを正しく入力すると特別日がデータベースに保存され、特別日一覧にリダイレクトする" do
@@ -30,8 +30,8 @@ RSpec.describe "SpecialDays", type: :system do
           click_button "保存"
         }.to change { SpecialDay.count }.by(1)
 
-        expect(page).to have_content("特別日が作成されました")
-        expect(page).to have_current_path(admins_special_days_path)
+        expect(page).to have_content "特別日が作成されました"
+        expect(page).to have_current_path admins_special_days_path
       end
 
       it "入力が正しくないと、エラーメッセージが表示される" do
@@ -41,7 +41,7 @@ RSpec.describe "SpecialDays", type: :system do
         fill_in "手当", with: 1500
         click_button "保存"
 
-        expect(page).to have_content("開始日を入力してください")
+        expect(page).to have_content "開始日を入力してください"
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe "SpecialDays", type: :system do
       it "特別日作成画面へのアクセスが失敗し、管理ログイン画面にリダイレクトされる" do
         visit new_admins_special_day_path
 
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe "SpecialDays", type: :system do
       it "アクセスが失敗し、管理ログイン画面にリダイレクトされる" do
         visit new_admins_special_day_path
 
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
   end
@@ -76,45 +76,45 @@ RSpec.describe "SpecialDays", type: :system do
       end
 
       it "特別日一覧画面にアクセスが成功する" do
-        expect(page).to have_title("特別日一覧")
+        expect(page).to have_title "特別日一覧"
       end
 
       it "作成日が新しい順で特別日が表示される" do
-        expect(page).to have_content("100 件中 0 〜 10 件")
+        expect(page).to have_content "100 件中 0 〜 10 件"
       end
 
       it "2ページ目への移動が成功する" do
         click_link "2"
-        expect(page).to have_current_path(admins_special_days_path(page: 2))
-        expect(page).to have_content("100 件中 10 〜 20 件")
+        expect(page).to have_current_path admins_special_days_path(page: 2)
+        expect(page).to have_content "100 件中 10 〜 20 件"
       end
 
       it "次のページへの移動が成功する" do
         visit admins_special_days_path
         click_link "›"
-        expect(page).to have_current_path(admins_special_days_path(page: 2))
-        expect(page).to have_content("100 件中 10 〜 20 件")
+        expect(page).to have_current_path admins_special_days_path(page: 2)
+        expect(page).to have_content "100 件中 10 〜 20 件"
       end
 
       it "最後のページへの移動が成功する" do
         visit admins_special_days_path
         click_link "»"
-        expect(page).to have_current_path(admins_special_days_path(page: 10))
-        expect(page).to have_content("100 件中 90 〜 100 件")
+        expect(page).to have_current_path admins_special_days_path(page: 10)
+        expect(page).to have_content "100 件中 90 〜 100 件"
       end
 
       it "前のページへの移動が成功する" do
         visit admins_special_days_path(page: 2)
         click_link "‹"
-        expect(page).to have_current_path(admins_special_days_path)
-        expect(page).to have_content("100 件中 0 〜 10 件")
+        expect(page).to have_current_path admins_special_days_path
+        expect(page).to have_content "100 件中 0 〜 10 件"
       end
 
       it "最初のページへの移動が成功する" do
         visit admins_special_days_path(page: 10)
         click_link "«"
-        expect(page).to have_current_path(admins_special_days_path)
-        expect(page).to have_content("100 件中 0 〜 10 件")
+        expect(page).to have_current_path admins_special_days_path
+        expect(page).to have_content "100 件中 0 〜 10 件"
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe "SpecialDays", type: :system do
       it "特別日一覧画面へのアクセスが失敗し、管理ログイン画面にリダイレクトされる" do
         visit admins_special_days_path
 
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
 
@@ -134,7 +134,7 @@ RSpec.describe "SpecialDays", type: :system do
       it "アクセスが失敗し、管理ログイン画面にリダイレクトされる" do
         visit admins_special_days_path
 
-        expect(page).to have_current_path(new_admin_session_path)
+        expect(page).to have_current_path new_admin_session_path
       end
     end
   end

--- a/rails/spec/system/users_spec.rb
+++ b/rails/spec/system/users_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Users", type: :system do
         fill_in_registration_form(valid_user_info)
         click_button "登録"
 
-        expect(page).to have_content("アカウント登録が完了しました")
+        expect(page).to have_content "アカウント登録が完了しました"
         expect(User.find_by(email: "test@example.com")).not_to be_nil
       end
 
@@ -60,7 +60,7 @@ RSpec.describe "Users", type: :system do
         fill_in_registration_form(invalid_user_info)
         click_button "登録"
 
-        expect(page).to have_content("アカウント登録に失敗しました")
+        expect(page).to have_content "アカウント登録に失敗しました"
         expect(User.find_by(email: "test@example.com")).to be_nil
       end
     end
@@ -76,8 +76,8 @@ RSpec.describe "Users", type: :system do
       it "アカウント登録ページに遷移しようとするとカレンダーページにリダイレクトされる" do
         visit new_user_registration_path
 
-        expect(page).to have_current_path(root_path)
-        expect(page).to have_content("すでにログイン済みです")
+        expect(page).to have_current_path root_path
+        expect(page).to have_content "すでにログイン済みです"
       end
     end
   end
@@ -93,8 +93,8 @@ RSpec.describe "Users", type: :system do
         visit new_user_session_path
         fill_in_login_form(valid_login_info)
         click_button "ログイン"
-        expect(page).to have_content("ログインしました")
-        expect(page).to have_link("ログアウト")
+        expect(page).to have_content "ログインしました"
+        expect(page).to have_link "ログアウト"
         expect(User.find_by(email: "test@example.com")).not_to be_nil
       end
 
@@ -103,7 +103,7 @@ RSpec.describe "Users", type: :system do
         fill_in_login_form(invalid_email_info)
         click_button "ログイン"
 
-        expect(page).to have_content("メールアドレスかパスワードが間違っています")
+        expect(page).to have_content "メールアドレスかパスワードが間違っています"
       end
 
       it "間違ったパスワードでログインが失敗する" do
@@ -111,7 +111,7 @@ RSpec.describe "Users", type: :system do
         fill_in_login_form(invalid_password_info)
         click_button "ログイン"
 
-        expect(page).to have_content("メールアドレスかパスワードが間違っています")
+        expect(page).to have_content "メールアドレスかパスワードが間違っています"
       end
     end
 
@@ -123,8 +123,8 @@ RSpec.describe "Users", type: :system do
       it "ログインページに遷移しようとするとカレンダーページにリダイレクトされる" do
         visit new_user_session_path
 
-        expect(page).to have_current_path(root_path)
-        expect(page).to have_content("すでにログイン済みです")
+        expect(page).to have_current_path root_path
+        expect(page).to have_content "すでにログイン済みです"
       end
     end
   end
@@ -139,11 +139,11 @@ RSpec.describe "Users", type: :system do
     it "ログアウトが成功する" do
       visit root_path
       click_link "ログアウト"
-      expect(page).to have_content("ログアウトしました")
-      expect(page).to have_current_path(new_user_session_path)
-      expect(page).to have_link("ログイン")
-      expect(page).to have_link("アカウント登録")
-      expect(page).not_to have_link("ログアウト")
+      expect(page).to have_content "ログアウトしました"
+      expect(page).to have_current_path new_user_session_path
+      expect(page).to have_link "ログイン"
+      expect(page).to have_link "アカウント登録"
+      expect(page).not_to have_link "ログアウト"
     end
   end
 
@@ -152,7 +152,7 @@ RSpec.describe "Users", type: :system do
       it "マイページにアクセスしようとするとログインページにリダイレクトされる" do
         visit mypage_path
 
-        expect(page).to have_current_path(new_user_session_path)
+        expect(page).to have_current_path new_user_session_path
       end
     end
 
@@ -166,9 +166,9 @@ RSpec.describe "Users", type: :system do
 
       it "マイページへのアクセスが成功する" do
         visit mypage_path
-        expect(page).to have_title("マイページ")
-        expect(page).to have_content("アカウント情報")
-        expect(page).to have_content("給与情報")
+        expect(page).to have_title "マイページ"
+        expect(page).to have_content "アカウント情報"
+        expect(page).to have_content "給与情報"
       end
     end
   end


### PR DESCRIPTION
行ったこと
- 管理勤怠一覧機能作成
- 管理勤怠一覧のシステムスペックを作成
- 特別日の取得をリファクタリング
- システムスペックのhave_のメソッドの書き方を統一

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
    - 管理者向けの勤怠管理ページを追加し、管理者が勤怠記録を表示・管理できるようになりました。

- **バグ修正**
    - 管理者ログインのリダイレクトURLを正しいURLに修正しました。
    - 特別日表示とロジックを修正し、特別日の設定が適切に反映されるようにしました。

- **UI改善**
    - 管理者レイアウトにリンクを追加し、「勤怠管理」ページへのアクセスが容易に。
    - 管理画面の勤怠一覧ページにページネーション機能を追加しました。

- **テスト**
    - 管理者向けの勤怠管理機能に対するシステムテストを追加しました。
    - 特別日管理機能およびユーザー管理機能のテストを改善し、読みやすさと保守性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->